### PR TITLE
Added missing map connection from Alpha FC to East End.

### DIFF
--- a/suspended/rooms.zil
+++ b/suspended/rooms.zil
@@ -1617,6 +1617,7 @@ data energy into an object surrounding me. Sensors detect a similar channeling t
 "The first stage of our journey begins here, the music goes round and round."
 "I stand within the first Filtering Computer, a massive device used to interface us with you and maintain the surface systems.">)
       (SOUTH TO TUBE2)
+      (SW TO MIDMIST)
       (LINE 2)
       (STATION FC1)
       (GLOBAL AIRCON)>


### PR DESCRIPTION
There is a missing map connection between Alpha FC and East End, and this pull request adds it. This change is untested (I haven't been able to get ZILF running on my computer), but I think it's correct.