### PR TITLE
Fixed minor corruption at the end of comptwo.zil

### DIFF
--- a/planetfall/comptwo.zil
+++ b/planetfall/comptwo.zil
@@ -3086,4 +3086,4 @@ fear of light." CR>)>>
 toward you on three leg-like stalks.")
 	(SYNONYM TRIFFID PLANT MUTANT MONSTER)
 	(ADJECTIVE MOBILE MAN-EATING GIANT)
-	(FLAGS ACTORBIL M
+	(FLAGS ACTORBIT)>


### PR DESCRIPTION
This is untested, but should be correct. I've checked against both the Solid Gold version, and an earlier version of the game.