### PR TITLE
Fix various typos

### DIFF
--- a/bureaucracy/verbs.zil
+++ b/bureaucracy/verbs.zil
@@ -3585,7 +3585,7 @@ stay right there." CR>
 	<TABLE (LENGTH PATTERN (BYTE [REST WORD]))
 	       #BYTE 0 
 	 "is not permitted in this story without prior written consent, in triplicate, from Infocom, Inc"
-	 "is a violation of the Cambridge Convention, which prohibits it in humourous games"
+	 "is a violation of the Cambridge Convention, which prohibits it in humorous games"
 	 "cannot be allowed until your bank acknowledges your change-of-address form"
 	 "may not be attempted by anyone using a computer"
 	 "is not permitted until you obtain your physician's approval, and submit Form 691/05/Z, in person, to the Office of Forms in Vladivostok">>

--- a/deadline/actions.zil
+++ b/deadline/actions.zil
@@ -945,7 +945,7 @@ He hesitates suddenly, pen in hand." CR>
 		       <TELL
 "\"A fascinating story, Inspector. A man is found dead behind a locked door,
 a clear suicide. Yet the detective seems bent on proving that a murder has
-occured. Rather odd, wouldn't you say?\"" CR>)
+occurred. Rather odd, wouldn't you say?\"" CR>)
 		      (<==? ,PRSI ,GLOBAL-CONCERT>
 		       <TELL
 "\"A marvelous concert! There were works by Beethoven, Sibelius, and Ravel. I

--- a/enchanter/terror.zil
+++ b/enchanter/terror.zil
@@ -833,7 +833,7 @@ Implementers." CR>)
 	(TEXT
 "This legend, written in an ancient tongue, goes something like this:
 At one time a shapeless and formless manifestation of evil was disturbed
-from millenia of sleep. It was so powerful that it required the combined
+from millennia of sleep. It was so powerful that it required the combined
 wisdom of the leading enchanters of that age to conquer it. The legend tells
 how the enchanters lured the Terror \"to a recess deep within the earth\" by
 placing there a powerful spell scroll. When it had reached the scroll, the

--- a/hitchhikersguide-gold/unearth.zil
+++ b/hitchhikersguide-gold/unearth.zil
@@ -593,7 +593,7 @@ now, the hot breath of our vengeance blows hard upon this little world...\"|
 		       <RESTORE-INPUT ,FIRST-BUFFER>
 		       <TELL "'.\"|
   \"Yes, there's no need to keep repeating it,\" growls the Vl'Hurg.|
-  \"One happy thought,\" adds the G'Gugvunt. \"After millenia of bloody
+  \"One happy thought,\" adds the G'Gugvunt. \"After millennia of bloody
 and perpetual conflict, our races have been brought together by this
 Quest for the Source of the Offending Remark. Perhaps, after our vengeance
 has been exacted on him who said '">

--- a/hitchhikersguide/unearth.zil
+++ b/hitchhikersguide/unearth.zil
@@ -586,7 +586,7 @@ now, the hot breath of our vengeance blows hard upon this little world...\"|
 		       <RESTORE-INPUT ,FIRST-BUFFER>
 		       <TELL "'.\"|
   \"Yes, there's no need to keep repeating it,\" growls the Vl'Hurg.|
-  \"One happy thought,\" adds the G'Gugvunt. \"After millenia of bloody
+  \"One happy thought,\" adds the G'Gugvunt. \"After millennia of bloody
 and perpetual conflict, our races have been brought together by this
 Quest for the Source of the Offending Remark. Perhaps, after our vengeance
 has been exacted on him who said '">

--- a/infocom-sampler/dungeon.zil
+++ b/infocom-sampler/dungeon.zil
@@ -1121,7 +1121,7 @@ The rain outside is falling heavily now.|
 The note is written in a spidery hand on fine rag paper. It says:|
 \"Linder --|
 Since Virginia died, I've lost too much sleep because of you and
-your harrassments. The time has come to put this matter to rest
+your harassments. The time has come to put this matter to rest
 once and for all. I'll be seeing you sooner than you imagine.|
               -- Stiles\"|
 |

--- a/infocom-sampler/planetfall.zil
+++ b/infocom-sampler/planetfall.zil
@@ -270,7 +270,7 @@ deserted now. There are openings at the north and south ends of the room.")
       (LDESC
 "This must be the sanitary facility for the adjacent dormitory. The fixtures
 are dry and dusty, the room dead and deserted. You marvel at how little the
-millenia and cultural gulfs have changed toilet bowl design. The only exit is
+millennia and cultural gulfs have changed toilet bowl design. The only exit is
 north.")
       (C-MOVE  <TABLE
          ;"OUT" 0 ;"IN"   0 ;"DOWN" 0  ;"UP"     0
@@ -304,7 +304,7 @@ deserted now. There are openings at the north and south ends of the room.")
       (LDESC
 "This must be the sanitary facility for the adjacent dormitory. The fixtures
 are dry and dusty, the room dead and deserted. You marvel at how little the
-millenia and cultural gulfs have changed toilet bowl design. The only exit is
+millennia and cultural gulfs have changed toilet bowl design. The only exit is
 south.")
       (C-MOVE  <TABLE
          ;"OUT" 0 ;"IN"   0 ;"DOWN" 0  ;"UP"     0

--- a/journey/combat.zil
+++ b/journey/combat.zil
@@ -313,7 +313,7 @@ appeared that ">
 
 <CONSTANT AGGRESSION-TBL
 	  <TABLE "a decidedly defensive" "a defensive" "a somewhat defensive"
-		 "a balanced" "an aggressive" "an agressive"
+		 "a balanced" "an aggressive" "an aggressive"
 		 "a boldly aggressive" "an all-out aggressive"
 		 "an almost suicidally aggressive">>
 

--- a/journey/hints.zil
+++ b/journey/hints.zil
@@ -319,7 +319,7 @@ surrounding his acquisition of the mysterious map we purchased.">)
 Webba's meant. Perhaps if we had spoken to him, he would have explained.">)
 	       (T
 		<TELL
-"I don't know how we might have avoided the grizzly scene at the Sunrise
+"I don't know how we might have avoided the grisly scene at the Sunrise
 Mountain. We had no map, and all paths looked similar. Perhaps it was
 unavoidable.">)>
 	 <UPDATE-REMOVE ,ACTION-OBJECT>>

--- a/leathergoddesses-gold/mars.zil
+++ b/leathergoddesses-gold/mars.zil
@@ -1736,7 +1736,7 @@ an opening between the dunes leads west.")
       (DESC "Canalview Mall")
       (LDESC
 "As with all Martian civilization, this once-fashionable shopping center has
-fallen upon hard times; the only store to have endured the fifteen-millenia
+fallen upon hard times; the only store to have endured the fifteen-millennia
 recession lies to the south. The canal is still as visible as it was when
 scheming marketeers misnamed the mall generations ago -- in other words, not
 at all. A path leads east, and a dune to the west seems mountable.")

--- a/leathergoddesses/mars.zil
+++ b/leathergoddesses/mars.zil
@@ -1650,7 +1650,7 @@ an opening between the dunes leads west.")
       (DESC "Canalview Mall")
       (LDESC
 "As with all Martian civilization, this once-fashionable shopping center has
-fallen upon hard times; the only store to have endured the fifteen-millenia
+fallen upon hard times; the only store to have endured the fifteen-millennia
 recession lies to the south. The canal is still as visible as it was when
 scheming marketeers misnamed the mall generations ago -- in other words, not
 at all. A path leads east, and a dune to the west seems mountable.")

--- a/nordandbert/verbs.zil
+++ b/nordandbert/verbs.zil
@@ -1116,7 +1116,7 @@ flings " .STR " away over the shelves" >
 		<UPDATE-SCORE>
 		<SETG MINCE-EATEN T>
 		<TELL
-		 ". There's a noticable improvement in his breath, even from here">)>
+		 ". There's a noticeable improvement in his breath, even from here">)>
 		<TELL ,PERIOD>>
 
 <ROUTINE GIVE-TO-ROCKS ()

--- a/planetfall-gold/compone.zil
+++ b/planetfall-gold/compone.zil
@@ -366,7 +366,7 @@ deserted now. There are openings at the north and south ends of the room.")
       (LDESC
 "This must be the sanitary facility for the adjacent dormitory. The fixtures
 are dry and dusty, the room dead and deserted. You marvel at how little the
-millenia and cultural gulfs have changed toilet bowl design. The only exit is
+millennia and cultural gulfs have changed toilet bowl design. The only exit is
 north.")
       (C-MOVE  <TABLE
          ;"OUT" 0 ;"IN"   0 ;"DOWN" 0  ;"UP"     0
@@ -400,7 +400,7 @@ deserted now. There are openings at the north and south ends of the room.")
       (LDESC
 "This must be the sanitary facility for the adjacent dormitory. The fixtures
 are dry and dusty, the room dead and deserted. You marvel at how little the
-millenia and cultural gulfs have changed toilet bowl design. The only exit is
+millennia and cultural gulfs have changed toilet bowl design. The only exit is
 south.")
       (C-MOVE  <TABLE
          ;"OUT" 0 ;"IN"   0 ;"DOWN" 0  ;"UP"     0
@@ -434,7 +434,7 @@ deserted now. There are openings at the north and south ends of the room.")
       (LDESC
 "This must be the sanitary facility for the adjacent dormitory. The fixtures
 are dry and dusty, the room dead and deserted. You marvel at how little the
-millenia and cultural gulfs have changed toilet bowl design. The only exit is
+millennia and cultural gulfs have changed toilet bowl design. The only exit is
 north.")
       (C-MOVE  <TABLE
          ;"OUT" 0 ;"IN"   0 ;"DOWN" 0  ;"UP"     0
@@ -468,7 +468,7 @@ deserted now. There are openings at the north and south ends of the room.")
       (LDESC
 "This must be the sanitary facility for the adjacent dormitory. The fixtures
 are dry and dusty, the room dead and deserted. You marvel at how little the
-millenia and cultural gulfs have changed toilet bowl design. The only exit is
+millennia and cultural gulfs have changed toilet bowl design. The only exit is
 south.")
       (C-MOVE  <TABLE
          ;"OUT" 0 ;"IN"   0 ;"DOWN" 0  ;"UP"     0

--- a/planetfall-gold/globals.zil
+++ b/planetfall-gold/globals.zil
@@ -2986,7 +2986,7 @@ Planetfall, you blow it all in one amazingly dumb input.|
 |
 The doors close and the elevator rises quickly to the top of the shaft. The
 doors open, and the mutants, which were waiting impatiently in the ProjCon
-Office for just such an occurence, happily saunter in and begin munching.">)>>
+Office for just such an occurrence, happily saunter in and begin munching.">)>>
 
 <ROUTINE CASTLE-PSEUDO ()
 	 <COND (<VERB? EXAMINE>

--- a/planetfall-gold/globals.zil
+++ b/planetfall-gold/globals.zil
@@ -1263,7 +1263,7 @@ translator slung around his neck." CR>)
 	 <COND (<AND <VERB? EXAMINE>
 		     <EQUAL? .RARG ,M-OBJECT>>
 		<TELL
-"The safety webbing fills most of the pod. It could accomodate
+"The safety webbing fills most of the pod. It could accommodate
 from one to, perhaps, twenty people." CR>)
 	       (<AND <VERB? TAKE>
 		     <EQUAL? .RARG ,M-OBJECT>>

--- a/planetfall/compone.zil
+++ b/planetfall/compone.zil
@@ -366,7 +366,7 @@ deserted now. There are openings at the north and south ends of the room.")
       (LDESC
 "This must be the sanitary facility for the adjacent dormitory. The fixtures
 are dry and dusty, the room dead and deserted. You marvel at how little the
-millenia and cultural gulfs have changed toilet bowl design. The only exit is
+millennia and cultural gulfs have changed toilet bowl design. The only exit is
 north.")
       (C-MOVE  <TABLE
          ;"OUT" 0 ;"IN"   0 ;"DOWN" 0  ;"UP"     0
@@ -400,7 +400,7 @@ deserted now. There are openings at the north and south ends of the room.")
       (LDESC
 "This must be the sanitary facility for the adjacent dormitory. The fixtures
 are dry and dusty, the room dead and deserted. You marvel at how little the
-millenia and cultural gulfs have changed toilet bowl design. The only exit is
+millennia and cultural gulfs have changed toilet bowl design. The only exit is
 south.")
       (C-MOVE  <TABLE
          ;"OUT" 0 ;"IN"   0 ;"DOWN" 0  ;"UP"     0
@@ -434,7 +434,7 @@ deserted now. There are openings at the north and south ends of the room.")
       (LDESC
 "This must be the sanitary facility for the adjacent dormitory. The fixtures
 are dry and dusty, the room dead and deserted. You marvel at how little the
-millenia and cultural gulfs have changed toilet bowl design. The only exit is
+millennia and cultural gulfs have changed toilet bowl design. The only exit is
 north.")
       (C-MOVE  <TABLE
          ;"OUT" 0 ;"IN"   0 ;"DOWN" 0  ;"UP"     0
@@ -468,7 +468,7 @@ deserted now. There are openings at the north and south ends of the room.")
       (LDESC
 "This must be the sanitary facility for the adjacent dormitory. The fixtures
 are dry and dusty, the room dead and deserted. You marvel at how little the
-millenia and cultural gulfs have changed toilet bowl design. The only exit is
+millennia and cultural gulfs have changed toilet bowl design. The only exit is
 south.")
       (C-MOVE  <TABLE
          ;"OUT" 0 ;"IN"   0 ;"DOWN" 0  ;"UP"     0

--- a/planetfall/globals.zil
+++ b/planetfall/globals.zil
@@ -2704,7 +2704,7 @@ Planetfall, you blow it all in one amazingly dumb input.|
 |
 The doors close and the elevator rises quickly to the top of the shaft. The
 doors open, and the mutants, which were waiting impatiently in the ProjCon
-Office for just such an occurence, happily saunter in and begin munching.">)>>
+Office for just such an occurrence, happily saunter in and begin munching.">)>>
 
 <ROUTINE CASTLE-PSEUDO ()
 	 <COND (<VERB? EXAMINE>

--- a/planetfall/globals.zil
+++ b/planetfall/globals.zil
@@ -992,7 +992,7 @@ translator slung around his neck." CR>)
 	 <COND (<AND <VERB? EXAMINE>
 		     <EQUAL? .RARG ,M-OBJECT>>
 		<TELL
-"The safety webbing fills most of the pod. It could accomodate
+"The safety webbing fills most of the pod. It could accommodate
 from one to, perhaps, twenty people." CR>)
 	       (<AND <VERB? TAKE>
 		     <EQUAL? .RARG ,M-OBJECT>>

--- a/shogun/anjiro.zil
+++ b/shogun/anjiro.zil
@@ -2947,7 +2947,7 @@ agree, say it directly to him.\"" CR>)
 			(<NOT <B-LYING?>>
 			 <COND (<EQUAL? ,DELAY-CNT 1>
 				<TELL CR
-"Omi watches you with great curiousity." CR>
+"Omi watches you with great curiosity." CR>
 				<RTRUE>)
 			       (<EQUAL? <CROOCQ-IN-CAULDRON> T>
 				<COND (<EQUAL? ,DELAY-CNT 2 3>

--- a/stationfall/station.zil
+++ b/stationfall/station.zil
@@ -2054,7 +2054,7 @@ more exotic plants, and returns to the area near the elevator.")
 	 <COND (<EQUAL? .RARG ,M-LOOK>
 		<TELL
 "This is inarguably the most bucolic spot aboard the station. Pebbled paths
-wind among beautiful and exotic shrubbery, culled from millenia of galactic
+wind among beautiful and exotic shrubbery, culled from millennia of galactic
 exploration. " ,DOME-DESC " East of where you are standing are an elevator">
 		<COND (<NOT <EQUAL? ,ELEVATOR-LEVEL 1>>
 		       <TELL " shaft">)>
@@ -3545,7 +3545,7 @@ this is fatal. But before I do, human, perhaps it will interest you to discover
 the reason for your demise, and why the rest of your worthless race will soon
 follow.|
    \"You see, eons ago, two races in another galaxy, the Zeenaks and the Hunji,
-were involved in an interstellar war. The war had raged for countless millenia
+were involved in an interstellar war. The war had raged for countless millennia
 before the Zeenaks devised an ultimate weapon, a device that would be launched
 into Hunji space. There, via methods beyond your comprehension, it would
 influence all the machines within a certain range to turn against their Hunji

--- a/stationfall/verbs.zil
+++ b/stationfall/verbs.zil
@@ -2424,7 +2424,7 @@ the door tries to shut, almost jamming against you!">
 		<COND (<NOT <FSET? ,AUTO-DOOR ,TOUCHBIT>>
 		       <FSET ,AUTO-DOOR ,TOUCHBIT>
 		       <TELL
-" Very puzzling; auto-doors have been around for millenia, and are
+" Very puzzling; auto-doors have been around for millennia, and are
 generally the epitome of reliability.">)>)>
 	 <CRLF> <CRLF>>
 

--- a/suspended/rooms.zil
+++ b/suspended/rooms.zil
@@ -1203,7 +1203,7 @@ violent force fields and electrical disturbances to the east."
 "Wiring etched into the walls branches off to the northeast from here, while an incredibly powerful source of energy is easily detectable to the east."
 "I can hear a difference in the air currents and air conditioning circuits here
 as if another passage started to the northeast."
-"The great interpreter of all our daily occurences lies ahead, while a walk in
+"The great interpreter of all our daily occurrences lies ahead, while a walk in
 the sky waits for me to the northeast."
 "CLC indicates I have arrived at a northeast branch in the corridor." >)
       (WEST TO CORRIDOR-3)

--- a/witness/things.zil
+++ b/witness/things.zil
@@ -513,7 +513,7 @@ again." CR>)
 "The note is written in a spidery hand on fine rag paper. It says:|
 \"Linder --|
 Since Virginia died, I've lost too much sleep because of you and
-your harrassments. The time has come to put this matter to rest
+your harassments. The time has come to put this matter to rest
 once and for all. I'll be seeing you sooner than you imagine.|
               -- Stiles\"")>
 

--- a/zork3/3actions.zil
+++ b/zork3/3actions.zil
@@ -892,14 +892,14 @@ would be a bit one-sided." CR>)
 			      <SETG MR1-FLAG <>>
 			      <TELL
 "The mirror breaks, revealing a wooden panel behind it. The glistening
-fragments of mirror quietly sparkle into nonexistance." CR>)
+fragments of mirror quietly sparkle into nonexistence." CR>)
 			     (T <TELL "The mirror has already been broken."
 				      CR>)>)
 		      (,MR2-FLAG
 		       <SETG MR2-FLAG <>>
 		       <TELL
 "The mirror breaks, revealing a wooden panel behind it. The glistening
-fragments of mirror quietly sparkle into nonexistance." CR>)
+fragments of mirror quietly sparkle into nonexistence." CR>)
 		      (T <TELL "The mirror has already been broken." CR>)>)
 	       (<OR <AND <==? .MIRROR 1> <NOT ,MR1-FLAG>> <NOT ,MR2-FLAG>>
 	        <TELL

--- a/zorkzero/castle.zil
+++ b/zorkzero/castle.zil
@@ -1969,7 +1969,7 @@ you plunge into the moat and are devoured by ravenous alligators.">)>
       (DESC "Bastion")
       (LDESC
 "This room occupies a taller tower rising from the corner of the keep.
-The slitted windows are wider here, presumably to accomodate the weaponry
+The slitted windows are wider here, presumably to accommodate the weaponry
 of the period. The stair winds up and down from here.")
       (UP TO PARAPET)
       (DOWN TO SOLAR)

--- a/zorkzero/library.zil
+++ b/zorkzero/library.zil
@@ -122,7 +122,7 @@ the source of the Frigid River. The article goes into construction techniques,
 the dam's appeal as a tourist attraction, and the financial impact of the
 dam's cost on the economy of the GUE."
  DIABLO MASSACRE
-"\"The Diablo Massacre occured at the Zorbel Pass in 666 GUE when the invading
+"\"The Diablo Massacre occurred at the Zorbel Pass in 666 GUE when the invading
 armies of King Duncanthrax met a native militia of trollish warriors. The
 invaders were outnumbered but well-armed; the natives were equipped only with
 wooden clubs and a large piece of very strong garlic. Military historians


### PR DESCRIPTION
I don't know if ZILF has an option, like Inform 6, to dump the game's text to a file where it can then be spellchecked. But in the meantime I've gone through a list of common English misspellings and searched the source code for them.

Since I'm not a native English speaker, I have tried verifying against the Merriam-Webster online dictionary. In case I still got it wrong, I've tried to keep one commit per word I've changed. (Some typos appear in multiple places, and that's of course still just one commit.)

I have not changed typos in comments - even when the comment is a removed piece of code - or other documents. I've also left "irresistable" in Arthur, since Merriam-Webster lists it as less common, but not as incorrect.